### PR TITLE
add acl json file

### DIFF
--- a/root/usr/share/rpcd/acl.d/luci-app-oled.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-oled.json
@@ -1,0 +1,11 @@
+{
+	"luci-app-oled": {
+		"description": "Grant UCI access for luci-app-oled",
+		"read": {
+			"uci": [ "oled" ]
+		},
+		"write": {
+			"uci": [ "oled" ]
+		}
+	}
+}


### PR DESCRIPTION
fix permission for openwrt master

Signed-off-by: Chuck <fanck0605@qq.com>

在自编译的固件上 luci 可以正常工作，但是二进制文件没法正常工作，当然这和 luci 无关