### PR TITLE
disable scroll display by default

### DIFF
--- a/root/etc/config/oled
+++ b/root/etc/config/oled
@@ -17,4 +17,5 @@ config oled
 	option cputemp '1'
 	option time '60'
 	option enable '0'
+	option scroll '0'
 


### PR DESCRIPTION
master 分支 luci 会默认开启 scroll，导致所有信息都不显示