### PR TITLE
optimize init.d script

### DIFF
--- a/root/etc/init.d/oled
+++ b/root/etc/init.d/oled
@@ -9,9 +9,8 @@ start() {
 		exit 0
 	fi
 	#crontab daemon
-	cat /etc/crontabs/root | grep oled > /dev/null
-	if [ $? -eq 1 ]; then
-		echo "*/5 * * * * /etc/init.d/oled restart &>/dev/null 2>&1" >> /etc/crontabs/root	
+	if ! grep "/etc/init.d/oled \+restart" /etc/crontabs/root >/dev/null 2>&1; then
+		echo "*/5 * * * * /etc/init.d/oled restart >/dev/null 2>&1" >> /etc/crontabs/root
 	fi
 
 	date=$(uci get oled.@oled[0].date)

--- a/root/etc/init.d/oled
+++ b/root/etc/init.d/oled
@@ -37,7 +37,7 @@ start() {
 	if [ ${netspeed} -eq 1 ]; then
 		nohup /usr/sbin/netspeed ${netsource} >/dev/null 2>&1 &
 	else
-		kill -9 $(pgrep -f netspeed)
+		kill -9 $(pgrep -f /usr/sbin/netspeed)
 		rm -f /tmp/netspeed
 	fi
 	nohup ${PROG} ${date} ${lanip} ${cputemp} ${cpufreq} ${netspeed} ${time} ${drawline} ${drawrect} ${fillrect} ${drawcircle} ${drawroundrect} ${fillroundrect} ${drawtriangle} ${filltriangle} ${displaybitmap} ${displayinvertnormal}  ${drawbitmapeg} ${scroll} "${text}" "${netsource}" 1 > /dev/null 2>&1 &
@@ -46,7 +46,7 @@ start() {
  
 stop() {
 	kill -9 $(pgrep /usr/bin/oled)
-	kill -9 $(pgrep -f netspeed)
+	kill -9 $(pgrep -f /usr/sbin/netspeed)
 	echo "oled exit..."
 }
 
@@ -56,7 +56,7 @@ restart(){
 	if [ $? -eq 0 ]; then
 		if [ $enabled -eq 1 ]; then
 			kill -9 $(pgrep /usr/bin/oled)
-			kill -9 $(pgrep -f netspeed)
+			kill -9 $(pgrep -f /usr/sbin/netspeed)
 
 			date=$(uci get oled.@oled[0].date)
 			lanip=$(uci get oled.@oled[0].lanip)
@@ -81,7 +81,7 @@ restart(){
 			if [ ${netspeed} -eq 1 ]; then
 				nohup /usr/sbin/netspeed ${netsource} >/dev/null 2>&1 &
 			else
-				kill -9 $(pgrep -f netspeed)
+				kill -9 $(pgrep -f /usr/sbin/netspeed)
 				rm -f /tmp/netspeed
 			fi
 			nohup ${PROG} ${date} ${lanip} ${cputemp} ${cpufreq} ${netspeed} ${time} ${drawline} ${drawrect} ${fillrect} ${drawcircle} ${drawroundrect} ${fillroundrect} ${drawtriangle} ${filltriangle} ${displaybitmap} ${displayinvertnormal}  ${drawbitmapeg} ${scroll} "${text}" "${netsource}" 0 > /dev/null 2>&1 &

--- a/root/etc/init.d/oled
+++ b/root/etc/init.d/oled
@@ -45,7 +45,7 @@ start() {
 
  
 stop() {
-	kill -2 `pgrep /usr/bin/oled`
+	kill -2 $(pgrep /usr/bin/oled)
 	ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
 	echo "oled exit..."
 }
@@ -55,7 +55,7 @@ restart(){
 	pgrep -f ${PROG} >/dev/null
 	if [ $? -eq 0 ]; then
 		if [ $enabled -eq 1 ]; then
-			kill `pgrep /usr/bin/oled`
+			kill $(pgrep /usr/bin/oled)
 			ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
 
 			date=$(uci get oled.@oled[0].date)

--- a/root/etc/init.d/oled
+++ b/root/etc/init.d/oled
@@ -37,7 +37,7 @@ start() {
 	if [ ${netspeed} -eq 1 ]; then
 		nohup /usr/sbin/netspeed ${netsource} >/dev/null 2>&1 &
 	else
-		ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
+		kill -9 $(pgrep -f netspeed)
 		rm -f /tmp/netspeed
 	fi
 	nohup ${PROG} ${date} ${lanip} ${cputemp} ${cpufreq} ${netspeed} ${time} ${drawline} ${drawrect} ${fillrect} ${drawcircle} ${drawroundrect} ${fillroundrect} ${drawtriangle} ${filltriangle} ${displaybitmap} ${displayinvertnormal}  ${drawbitmapeg} ${scroll} "${text}" "${netsource}" 1 > /dev/null 2>&1 &
@@ -46,7 +46,7 @@ start() {
  
 stop() {
 	kill -9 $(pgrep /usr/bin/oled)
-	ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
+	kill -9 $(pgrep -f netspeed)
 	echo "oled exit..."
 }
 
@@ -56,7 +56,7 @@ restart(){
 	if [ $? -eq 0 ]; then
 		if [ $enabled -eq 1 ]; then
 			kill -9 $(pgrep /usr/bin/oled)
-			ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
+			kill -9 $(pgrep -f netspeed)
 
 			date=$(uci get oled.@oled[0].date)
 			lanip=$(uci get oled.@oled[0].lanip)
@@ -81,7 +81,7 @@ restart(){
 			if [ ${netspeed} -eq 1 ]; then
 				nohup /usr/sbin/netspeed ${netsource} >/dev/null 2>&1 &
 			else
-				ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
+				kill -9 $(pgrep -f netspeed)
 				rm -f /tmp/netspeed
 			fi
 			nohup ${PROG} ${date} ${lanip} ${cputemp} ${cpufreq} ${netspeed} ${time} ${drawline} ${drawrect} ${fillrect} ${drawcircle} ${drawroundrect} ${fillroundrect} ${drawtriangle} ${filltriangle} ${displaybitmap} ${displayinvertnormal}  ${drawbitmapeg} ${scroll} "${text}" "${netsource}" 0 > /dev/null 2>&1 &

--- a/root/etc/init.d/oled
+++ b/root/etc/init.d/oled
@@ -45,7 +45,7 @@ start() {
 
  
 stop() {
-	kill -2 $(pgrep /usr/bin/oled)
+	kill -9 $(pgrep /usr/bin/oled)
 	ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
 	echo "oled exit..."
 }
@@ -55,7 +55,7 @@ restart(){
 	pgrep -f ${PROG} >/dev/null
 	if [ $? -eq 0 ]; then
 		if [ $enabled -eq 1 ]; then
-			kill $(pgrep /usr/bin/oled)
+			kill -9 $(pgrep /usr/bin/oled)
 			ps|grep netspeed|grep -v grep|awk '{print $1}'|xargs kill -9
 
 			date=$(uci get oled.@oled[0].date)


### PR DESCRIPTION
@NateLol 
1. 使用 $(command) 代替 \`command\`，\`\`  似乎已经弃用了
2. 全部使用 kill -9 彻底杀死进程
3. 使用 pgrep -f，而不是先 ps 再 grep，简化语句
4. 使用完整路径防误杀
5. 优化 crontab 脚本创建